### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/qc_lab/ingredients.py
+++ b/qc_lab/ingredients.py
@@ -328,7 +328,7 @@ def harmonic_oscillator_hop_function(model, parameters, **kwargs):
 
     If enough energy is available, the function returns the shift in the classical
     coordinates such that the new classical coordinate is z + shift and a boolean
-    indicating that the hop has occured. If not enough energy is available,
+    indicating that the hop has occurred. If not enough energy is available,
     the shift becomes zero and the boolean is False.
 
     Required Constants:
@@ -390,7 +390,7 @@ def free_particle_hop_function(model, parameters, **kwargs):
 
     If enough energy is available, the function returns the shift in the classical
     coordinates such that the new classical coordinate is z + shift and a boolean
-    indicating that the hop has occured. If not enough energy is available,
+    indicating that the hop has occurred. If not enough energy is available,
     the shift becomes zero and the boolean is False.
 
     Required Constants:

--- a/qc_lab/model.py
+++ b/qc_lab/model.py
@@ -9,7 +9,7 @@ from qc_lab.constants import Constants
 class Model:
     """
     The Model object provides the framework for defining the default constants of a model and
-    retreiving the ingredients of the model.
+    retrieving the ingredients of the model.
     """
 
     def __init__(self, default_constants=None, constants=None):

--- a/qc_lab/models/fmo_complex.py
+++ b/qc_lab/models/fmo_complex.py
@@ -9,8 +9,8 @@ from qc_lab import ingredients
 
 class FMOComplex(Model):
     """
-    A model representing a Fenna-Mathes-Olson (FMO) complex.
-    All unitless quantities in this model are taken to be in units of kBT at 298.15K.
+    A model representing a Fenna-Matthews-Olson (FMO) complex.
+    All unitless quantities in this model are taken to be in units of kBT at 298.15 K.
     """
 
     def __init__(self, constants=None):


### PR DESCRIPTION
## Summary
- fix typos in various docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68859e3614b88323b6dc51716474b16b