### PR TITLE
Standardize docstrings to Google style

### DIFF
--- a/qc_lab/algorithm.py
+++ b/qc_lab/algorithm.py
@@ -37,8 +37,17 @@ class Algorithm:
     collect_recipe = []
 
     def execute_recipe(self, sim, parameter, state, recipe):
-        """
-        Executes the given recipe for the simulation.
+        """Execute the given recipe for the simulation.
+
+        Args:
+            sim (Simulation): The simulation instance.
+            parameter (Variable): The parameter variable.
+            state (Variable): The state variable.
+            recipe (Iterable[callable]): Sequence of task functions.
+
+        Returns:
+            tuple[Variable, Variable]: The updated ``parameter`` and ``state``
+            objects.
         """
         for func in recipe:
             parameter, state = func(sim.algorithm, sim, parameter, state)

--- a/qc_lab/data.py
+++ b/qc_lab/data.py
@@ -19,13 +19,14 @@ class Data:
         self.data_dict = {"seed": seeds, "norm_factor": 0}
 
     def add_output_to_data_dict(self, sim, state, t_ind):
-        """
-        Add data to the output total arrays.
+        """Add data to the output total arrays.
 
         Args:
-            sim: The simulation object containing settings and parameters.
-            state: The state object containing the current simulation state.
-            t_ind: The current time index in the simulation.
+            sim (Simulation): The simulation object containing settings and
+                parameters.
+            state (Variable): The state object containing the current
+                simulation state.
+            t_ind (int): The current time index in the simulation.
         """
         # Check if the norm_factor is zero, if it is, save it from the state object.
         if self.data_dict["norm_factor"] == 0:
@@ -46,11 +47,11 @@ class Data:
             )
 
     def add_data(self, new_data):
-        """
-        Add new data to the existing data dictionary.
+        """Add new data to the existing data dictionary.
 
         Args:
-            new_data: A Data object containing the new data to be merged.
+            new_data (Data): A ``Data`` instance containing the new data to
+                merge.
         """
         new_norm_factor = (
             new_data.data_dict["norm_factor"] + self.data_dict["norm_factor"]
@@ -71,12 +72,13 @@ class Data:
         self.data_dict["norm_factor"] = new_norm_factor
 
     def save(self, filename):
-        """
-        Save the data as an h5 archive if h5py is available, if not
-        save each variable using numpy's savez function.
+        """Save the data to disk.
+
+        If ``h5py`` is available the data is stored as an HDF5 archive; otherwise
+        each variable is saved using :func:`numpy.savez`.
 
         Args:
-            filename: The name of the file to save the data to.
+            filename (str): The file name to save the data to.
         """
         if DISABLE_H5PY:
             np.savez(filename, **self.data_dict)
@@ -85,14 +87,13 @@ class Data:
                 self._recursive_save(h5file, "/", self.data_dict)
 
     def load(self, filename):
-        """
-        Load a data object from a file named filename.
+        """Load a :class:`Data` object from ``filename``.
 
         Args:
-            filename: The name of the file to load the data from.
+            filename (str): The file name to load the data from.
 
         Returns:
-            The Data object with the loaded data.
+            Data: The current instance populated with the loaded data.
         """
         if DISABLE_H5PY:
             loaded = np.load(filename)
@@ -103,13 +104,12 @@ class Data:
         return self
 
     def _recursive_save(self, h5file, path, dic):
-        """
-        Recursively saves dictionary contents to an HDF5 group.
+        """Recursively save dictionary contents to an HDF5 group.
 
         Args:
-            h5file: The HDF5 file object to save data into.
-            path: The current path in the HDF5 file.
-            dic: The dictionary to save.
+            h5file (h5py.File): The HDF5 file object to save data into.
+            path (str): The current path in the HDF5 file.
+            dic (dict): The dictionary to save.
         """
         for key, item in dic.items():
             if isinstance(
@@ -135,13 +135,12 @@ class Data:
                 raise ValueError(f"Cannot save {key} with type {type(item)}.")
 
     def _recursive_load(self, h5file, path, dic):
-        """
-        Recursively loads dictionary contents from an HDF5 group.
+        """Recursively load dictionary contents from an HDF5 group.
 
         Args:
-            h5file: The HDF5 file object to load data from.
-            path: The current path in the HDF5 file.
-            dic: The dictionary to populate with loaded data.
+            h5file (h5py.File): The HDF5 file object to load data from.
+            path (str): The current path in the HDF5 file.
+            dic (dict): The dictionary to populate with loaded data.
         """
         for key, item in h5file[path].items():
             if isinstance(item, h5py._hl.dataset.Dataset):

--- a/qc_lab/model.py
+++ b/qc_lab/model.py
@@ -27,8 +27,14 @@ class Model:
         self.update_dh_qc_dzc = True
 
     def get(self, ingredient_name):
-        """
-        Get the ingredient by its name. Returns the first instance of the ingredient in reverse order.
+        """Retrieve an ingredient by name.
+
+        Args:
+            ingredient_name (str): Name of the ingredient to search for.
+
+        Returns:
+            tuple[callable | None, bool]: The ingredient function (or ``None`` if
+            not found) and a flag indicating whether it exists.
         """
         for ingredient in self.ingredients[::-1]:
             if ingredient[0] == ingredient_name and ingredient[1] is not None:

--- a/qc_lab/variable.py
+++ b/qc_lab/variable.py
@@ -15,38 +15,54 @@ class Variable:
         self.seed = None
 
     def __getattr__(self, name):
-        """
-        If an attribute is not in the Variable object it returns None rather than throwing an error.
+        """Return ``None`` for missing attributes.
+
+        Args:
+            name (str): Attribute name.
+
+        Returns:
+            Any | None: The attribute value if present, otherwise ``None``.
         """
         if name in self.__dict__:
             return self.__dict__[name]
         return None
 
     def collect_outputs(self, names):
-        """
-        Collect attributes into the output dictionary.
+        """Collect attributes into the output dictionary.
 
         Args:
-            names: List of attribute names.
+            names (Iterable[str]): List of attribute names.
         """
         for var in names:
             self.output_dict[var] = getattr(self, var)
 
     def __getstate__(self):
-        """Called when pickling the object."""
+        """Support pickling of the object.
+
+        Returns:
+            dict: The instance dictionary used for pickling.
+        """
         state = self.__dict__.copy()
         return state
 
     def __setstate__(self, state):
+        """Restore state during unpickling.
+
+        Args:
+            state (dict): Object state.
+        """
         self.__dict__.update(state)
 
 
 def initialize_variable_objects(sim, seeds):
-    """
-    This generates the state and parameter objects for the simulation.
-    Each object in sim.state is initialized as a numpy array in the 
-    state object with a new first index corresponding to the number of trajectories
-    as specified by the length of the seeds array.
+    """Generate the ``parameter`` and ``state`` variables for a simulation.
+
+    Args:
+        sim (Simulation): The simulation instance.
+        seeds (Iterable[int]): Array of trajectory seeds.
+
+    Returns:
+        tuple[Variable, Variable]: The ``parameter`` and ``state`` objects.
     """
     state_variable = Variable()
     state_variable.seed = seeds


### PR DESCRIPTION
## Summary
- adopt Google style for parameter and return sections
- update docstrings in Data, Variable, Model and Algorithm modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm' / cannot load MPI library)*

------
https://chatgpt.com/codex/tasks/task_e_6885a3144d508323b9b95301fa202d01