### PR TITLE
Allow passing None to model constants

### DIFF
--- a/qc_lab/models/holstein_lattice.py
+++ b/qc_lab/models/holstein_lattice.py
@@ -14,7 +14,10 @@ class HolsteinLattice(Model):
     single optical mode.
     """
 
-    def __init__(self, constants={}):
+    def __init__(self, constants=None):
+        if constants is None:
+            constants = {}
+
         self.default_constants = {
             "kBT": 1,
             "g": 0.5,

--- a/qc_lab/models/simple_avoided_crossing.py
+++ b/qc_lab/models/simple_avoided_crossing.py
@@ -6,7 +6,9 @@ from qc_lab import ingredients
 class SimpleAvoidedCrossing(Model):
     """Tully's first problem, a simple avoided crossing."""
 
-    def __init__(self, constants={}):
+    def __init__(self, constants=None):
+        if constants is None:
+            constants = {}
 
         self.default_constants = dict(
             init_momentum=10,

--- a/qc_lab/models/spin_boson.py
+++ b/qc_lab/models/spin_boson.py
@@ -12,7 +12,10 @@ class SpinBoson(Model):
     Spin-Boson model class for the simulation framework.
     """
 
-    def __init__(self, constants={}):
+    def __init__(self, constants=None):
+        if constants is None:
+            constants = {}
+
         self.default_constants = {
             "kBT": 1,
             "V": 0.5,


### PR DESCRIPTION
## Summary
- accept `constants=None` in SpinBoson, HolsteinLattice and SimpleAvoidedCrossing
- handle `None` before merging default constants

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qc_lab._config')*

------
https://chatgpt.com/codex/tasks/task_e_6885a309e8bc83239b4a6aa64dca33ff