### PR TITLE
Add module docstrings

### DIFF
--- a/qc_lab/models/extended_coupling.py
+++ b/qc_lab/models/extended_coupling.py
@@ -1,3 +1,5 @@
+"""Model for Tully's third problem with extended coupling and reflection."""
+
 import numpy as np
 from qc_lab.model import Model
 from qc_lab import ingredients

--- a/qc_lab/models/simple_avoided_crossing.py
+++ b/qc_lab/models/simple_avoided_crossing.py
@@ -1,3 +1,5 @@
+"""Model representing Tully's first problem: a simple avoided crossing."""
+
 import numpy as np
 from qc_lab.model import Model
 from qc_lab import ingredients

--- a/qc_lab/tasks/collect_tasks.py
+++ b/qc_lab/tasks/collect_tasks.py
@@ -1,3 +1,5 @@
+"""Tasks that collect simulation results into output structures."""
+
 import numpy as np
 
 

--- a/qc_lab/tasks/default_ingredients.py
+++ b/qc_lab/tasks/default_ingredients.py
@@ -1,3 +1,5 @@
+"""Utility functions providing default task ingredients for simulations."""
+
 import numpy as np
 
 

--- a/qc_lab/tasks/initialization_tasks.py
+++ b/qc_lab/tasks/initialization_tasks.py
@@ -1,3 +1,5 @@
+"""Tasks used to initialize simulation parameters and state objects."""
+
 import numpy as np
 from qc_lab.tasks.default_ingredients import *
 

--- a/qc_lab/tasks/update_tasks.py
+++ b/qc_lab/tasks/update_tasks.py
@@ -1,3 +1,5 @@
+"""Tasks that update the simulation state during propagation."""
+
 import numpy as np
 import warnings
 from qc_lab.jit import njit


### PR DESCRIPTION
## Summary
- add high level module docstrings describing each model and task file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qc_lab._config')*

------
https://chatgpt.com/codex/tasks/task_e_6885a2f35954832382c957d937437e63