### PR TITLE
Use warnings for dummy jit decorators

### DIFF
--- a/qc_lab/jit.py
+++ b/qc_lab/jit.py
@@ -1,17 +1,22 @@
-"""
-This module provides dummy implementations of the `jit` and `njit` decorators
-from the `numba` library. These implementations are used when the `DISABLE_NUMBA`
-flag is set to `True`.
-"""
+"""Utilities for optional :mod:`numba` JIT compilation.
 
+This module provides dummy implementations of the ``jit`` and ``njit``
+decorators from :mod:`numba`. These no-op implementations are used when the
+``DISABLE_NUMBA`` flag is set to ``True`` or when :mod:`numba` is not available.
+"""
+import warnings
 from ._config import DISABLE_NUMBA
+
 
 
 def qc_lab_custom_jit(func=None, **kwargs):
     """
     Dummy jit decorator that does nothing if numba is not available.
     """
-    print("Using dummy jit decorator.")
+    warnings.warn(
+        "Numba is disabled; using dummy jit decorator.",
+        UserWarning,
+    )
 
     def decorator(func):
         return func
@@ -26,7 +31,10 @@ def qc_lab_custom_njit(func=None, **kwargs):
     """
     Dummy njit decorator that does nothing if numba is not available.
     """
-    print("Using dummy njit decorator.")
+    warnings.warn(
+        "Numba is disabled; using dummy njit decorator.",
+        UserWarning,
+    )
 
     def decorator(func):
         return func


### PR DESCRIPTION
## Summary
- improve jit.py docstring
- replace print statements with warnings when Numba is disabled

## Testing
- `pytest tests/test_drivers.py::test_drivers_spinboson -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6888ec7d5f248323806959de6daf53f0