### PR TITLE
Implement in-memory logging

### DIFF
--- a/qc_lab/__init__.py
+++ b/qc_lab/__init__.py
@@ -8,3 +8,24 @@ from qc_lab.data import Data
 from qc_lab.model import Model
 from qc_lab.algorithm import Algorithm
 from qc_lab.constants import Constants
+
+# Configure logging to capture all messages in memory. This needs to happen
+# on import so that any module using the standard logging facilities will have
+# its messages captured without printing to ``stdout``.
+from qc_lab.logger_utils import configure_memory_logger, get_log_output
+
+# Set up the logger with INFO level by default. The handler returned by this
+# function keeps all log messages in memory so they can later be attached to a
+# :class:`Data` instance.
+configure_memory_logger()
+
+__all__ = [
+    "Simulation",
+    "Variable",
+    "Data",
+    "Model",
+    "Algorithm",
+    "Constants",
+    "configure_memory_logger",
+    "get_log_output",
+]

--- a/qc_lab/dynamics/parallel_driver_mpi.py
+++ b/qc_lab/dynamics/parallel_driver_mpi.py
@@ -8,6 +8,7 @@ import numpy as np
 import qc_lab.dynamics as dynamics
 from qc_lab.data import Data
 from qc_lab.variable import initialize_variable_objects
+from qc_lab.logger_utils import get_log_output
 
 logger = logging.getLogger(__name__)
 
@@ -90,4 +91,7 @@ def parallel_driver_mpi(sim, seeds=None, data=None, num_tasks=None):
             data.add_data(result)
         data.data_dict["seed"] = seeds
 
+    # Attach collected log output on root rank
+    if rank == 0:
+        data.log = get_log_output()
     return data

--- a/qc_lab/dynamics/parallel_driver_multiprocessing.py
+++ b/qc_lab/dynamics/parallel_driver_multiprocessing.py
@@ -9,6 +9,7 @@ import numpy as np
 import qc_lab.dynamics as dynamics
 from qc_lab.data import Data
 from qc_lab.variable import initialize_variable_objects
+from qc_lab.logger_utils import get_log_output
 
 logger = logging.getLogger(__name__)
 
@@ -63,4 +64,6 @@ def parallel_driver_multiprocessing(sim, seeds=None, data=None, num_tasks=None):
         results = pool.starmap(dynamics.dynamics, input_data)
     for result in results:
         data.add_data(result)
+    # Attach collected log output
+    data.log = get_log_output()
     return data

--- a/qc_lab/dynamics/serial_driver.py
+++ b/qc_lab/dynamics/serial_driver.py
@@ -7,6 +7,7 @@ import numpy as np
 from qc_lab.data import Data
 from qc_lab.variable import initialize_variable_objects
 import qc_lab.dynamics as dynamics
+from qc_lab.logger_utils import get_log_output
 
 logger = logging.getLogger(__name__)
 
@@ -46,4 +47,6 @@ def serial_driver(sim, seeds=None, data=None):
         new_data.data_dict["seed"] = state.seed
         new_data = dynamics.dynamics(sim, parameters, state, new_data)
         data.add_data(new_data)
+    # Attach the collected log output to the data object before returning.
+    data.log = get_log_output()
     return data

--- a/qc_lab/logger_utils.py
+++ b/qc_lab/logger_utils.py
@@ -1,0 +1,30 @@
+import logging
+from io import StringIO
+
+_log_stream = StringIO()
+
+class QCDataHandler(logging.Handler):
+    """Logging handler that stores logs in memory."""
+
+    def emit(self, record):
+        msg = self.format(record)
+        _log_stream.write(msg + "\n")
+
+
+def configure_memory_logger(level=logging.INFO):
+    """Configure root logger to store logs without printing."""
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    # Remove existing handlers to avoid duplicate output
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+    handler = QCDataHandler()
+    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+    return handler
+
+
+def get_log_output() -> str:
+    """Return all collected log messages."""
+    return _log_stream.getvalue()


### PR DESCRIPTION
## Summary
- add new `logger_utils` module with in-memory handler
- configure logger on package import
- store log messages inside `Data`
- attach log output in driver functions

## Testing
- `pip install -e .[tests]`
- `pytest -q` *(fails: cannot load MPI library)*

------
https://chatgpt.com/codex/tasks/task_e_688a0c2417b08323b825f66f3cf13efe