### PR TITLE
Refactor recursive HDF5 save handling

### DIFF
--- a/qc_lab/data.py
+++ b/qc_lab/data.py
@@ -144,27 +144,15 @@ class Data:
             dic (dict): The dictionary to save.
         """
         for key, item in dic.items():
-            if isinstance(
-                item,
-                (
-                    np.ndarray,
-                    np.int64,
-                    np.float64,
-                    str,
-                    bytes,
-                    int,
-                    float,
-                    bool,
-                    complex,
-                ),
-            ):
-                h5file[path + key] = item
-            elif isinstance(item, dict):
+            if isinstance(item, dict):
                 self._recursive_save(h5file, path + key + "/", item)
-            elif isinstance(item, list):
-                h5file[path + key] = np.array(item)
             else:
-                raise ValueError(f"Cannot save {key} with type {type(item)}.")
+                try:
+                    h5file.create_dataset(path + key, data=np.asarray(item))
+                except TypeError as exc:
+                    raise ValueError(
+                        f"Cannot save {key} with unsupported type {type(item)}."
+                    ) from exc
 
     def _recursive_load(self, h5file, path, dic):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,38 @@
+"""Tests for :class:`qc_lab.data.Data` save and load functionality."""
+
+import numpy as np
+
+from qc_lab import Data
+
+
+def test_save_load_numpy_scalars_and_iterables(tmp_path):
+    """Ensure numpy scalar types and iterables persist through save/load."""
+
+    data = Data()
+    data.data_dict = {
+        "int32": np.int32(1),
+        "float32": np.float32(2.5),
+        "list": [1, 2, 3],
+        "tuple": (4, 5, 6),
+        "nested": {"inner_int32": np.int32(7), "inner_list": [8, 9]},
+    }
+
+    filename = tmp_path / "test.h5"
+    data.save(filename)
+
+    loaded = Data().load(filename)
+
+    assert isinstance(loaded.data_dict["int32"], np.int32)
+    assert loaded.data_dict["int32"] == np.int32(1)
+
+    assert isinstance(loaded.data_dict["float32"], np.float32)
+    assert loaded.data_dict["float32"] == np.float32(2.5)
+
+    assert np.array_equal(loaded.data_dict["list"], np.asarray([1, 2, 3]))
+    assert np.array_equal(loaded.data_dict["tuple"], np.asarray([4, 5, 6]))
+
+    nested = loaded.data_dict["nested"]
+    assert isinstance(nested["inner_int32"], np.int32)
+    assert nested["inner_int32"] == np.int32(7)
+    assert np.array_equal(nested["inner_list"], np.asarray([8, 9]))
+


### PR DESCRIPTION
## Summary
- Simplify `_recursive_save` by removing explicit type checks and using `np.asarray` to write datasets
- Add regression test to ensure numpy scalars and iterables save and load correctly

## Testing
- `pytest -m "not mpi" -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7979b2e548323bf134be6ed52fe7f