### PR TITLE
Enforce multiline docstrings and 88-column formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,38 +23,37 @@ extensions = [
     "sphinx.ext.duration",
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
-   "sphinx.ext.autosummary",
-   "sphinx.ext.mathjax",
-   "sphinx_design",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.mathjax",
+    "sphinx_design",
     "sphinx_togglebutton",
     "sphinxcontrib.mermaid",
     "sphinx.ext.graphviz",
 ]
-#graphviz_output_format = "svg"
+# graphviz_output_format = "svg"
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-#import sphinx_rtd_theme
-#html_theme = "sphinx_rtd_theme"
-#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_theme = "pydata_sphinx_theme" #"bizstyle"#
+# import sphinx_rtd_theme
+# html_theme = "sphinx_rtd_theme"
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "pydata_sphinx_theme"  # "bizstyle"#
 html_static_path = ["_static"]
-html_css_files=["custom.css"]
+html_css_files = ["custom.css"]
 html_theme_options = {
     "body_max_width": "100%",  # Remove maximum width constraint
     "github_url": "https://github.com/tempelaar-team/qc_lab",
     "collapse_navigation": True,
-    "show_nav_level":2,
+    "show_nav_level": 2,
     "secondary_sidebar_items": ["page-toc", "sourcelink"],
     "external_links_new_tab": True,
     "logo": {
         "image_light": "_static/images/logo-light.png",
         "image_dark": "_static/images/logo-dark.png",
-    }
+    },
 }
 
 html_sidebars = {

--- a/examples/mpi_examples/mpi_example.py
+++ b/examples/mpi_examples/mpi_example.py
@@ -1,7 +1,8 @@
 """
 This is an example of how to use the parallel_driver_mpi function in QC Lab.
 
-This script can either be executed by a scheduler like SLURM or can be called in terminal by running
+This script can either be executed by a scheduler like SLURM or can be called in
+terminal by running
 
 mpirun -n num_tasks python mpi_example.py
 

--- a/qc_lab/algorithm.py
+++ b/qc_lab/algorithm.py
@@ -1,5 +1,6 @@
 """
-This module contains the Algorithm class, which is the base class for Algorithm objects in QC Lab.
+This module contains the Algorithm class, which is the base class for Algorithm objects
+in QC Lab.
 """
 
 import copy
@@ -22,14 +23,17 @@ class Algorithm:
             setattr(self.settings, key, val)
         self.settings._init_complete = True
         self.update_algorithm_settings()
-        # Copy the recipes and output variables to ensure they are not shared across instances.
+        # Copy the recipes and output variables to ensure they are not shared
+        # across instances.
         self.initialization_recipe = copy.copy(self.initialization_recipe)
         self.update_recipe = copy.copy(self.update_recipe)
         self.collect_recipe = copy.copy(self.collect_recipe)
 
     def update_algorithm_settings(self):
         """
-        Update algorithm settings. This method should be overridden by subclasses.
+        Update algorithm settings.
+
+        This method should be overridden by subclasses.
         """
 
     initialization_recipe = []

--- a/qc_lab/constants.py
+++ b/qc_lab/constants.py
@@ -1,6 +1,6 @@
 """
-This module defines the Constants class, which is used to handle
-quantities that define simulation settings and model constants.
+This module defines the Constants class, which is used to handle quantities that define
+simulation settings and model constants.
 
 It also includes numerical constants.
 """
@@ -20,8 +20,8 @@ class Constants:
 
     def __setattr__(self, name, value):
         """
-        Overrides attribute setting to call the update function after the attribute is changed,
-        preventing recursion.
+        Overrides attribute setting to call the update function after the attribute is
+        changed, preventing recursion.
         """
         super().__setattr__(name, value)
         if not self._updating and name not in {

--- a/qc_lab/data.py
+++ b/qc_lab/data.py
@@ -1,6 +1,6 @@
 """
-This module defines the Data class, which is used to handle the collection and storage of data
-output from algorithms in QC Lab.
+This module defines the Data class, which is used to handle the collection and storage
+of data output from algorithms in QC Lab.
 """
 
 import logging

--- a/qc_lab/dynamics/serial_driver.py
+++ b/qc_lab/dynamics/serial_driver.py
@@ -34,7 +34,8 @@ def serial_driver(sim, seeds=None, data=None):
             num_trajs,
         )
         sim.settings.num_trajs = num_trajs
-    # Determine the number of simulations required to execute the total number of trajectories.
+    # Determine the number of simulations required to execute the total number
+    # of trajectories.
     num_sims = int(num_trajs / sim.settings.batch_size) + 1
 
     logger.info(

--- a/qc_lab/ingredients.py
+++ b/qc_lab/ingredients.py
@@ -1,7 +1,7 @@
 """
 This module contains ingredients for use in Model classes.
-It also contains any functions that the ingredients depend on
-for low-level operations.
+
+It also contains any functions that the ingredients depend on for low-level operations.
 """
 
 import functools
@@ -32,8 +32,8 @@ def qp_to_z(q, p, constants):
 
 def make_ingredient_sparse(ingredient):
     """
-    Wrapper that converts a vectorized ingredient output to a sparse format
-    consisting of the indices (inds), nonzero elements (mels), and shape.
+    Wrapper that converts a vectorized ingredient output to a sparse format consisting
+    of the indices (inds), nonzero elements (mels), and shape.
     """
 
     @functools.wraps(ingredient)
@@ -51,8 +51,9 @@ def make_ingredient_sparse(ingredient):
 def vectorize_ingredient(ingredient):
     """
     Wrapper that vectorize an ingredient function.
-    It assumes that any kwarg is an numpy.ndarray that is vectorized over its first index.
-    Other kwargs are assumed to not be vectorized.
+
+    It assumes that any kwarg is an numpy.ndarray that is vectorized over its first
+    index. Other kwargs are assumed to not be vectorized.
     """
 
     @functools.wraps(ingredient)
@@ -111,7 +112,9 @@ def h_c_free(model, parameters, **kwargs):
 @njit()
 def dh_c_dzc_harmonic_jit(z, h, w):
     """
-    Derivative of the harmonic oscillator classical Hamiltonian function with respect to the conjugate `z` coordinate.
+    Derivative of the harmonic oscillator classical Hamiltonian function with respect to
+    the conjugate `z` coordinate.
+
     This is a low-level function accelerated using Numba.
     """
     a = 0.5 * (((w**2) / h) - h)
@@ -122,8 +125,9 @@ def dh_c_dzc_harmonic_jit(z, h, w):
 
 def dh_c_dzc_harmonic(model, parameters, **kwargs):
     """
-    Derivative of the harmonic oscillator classical Hamiltonian function with respect to the conjugate `z` coordinate.
-    This is an ingredient that calls the low-level function `dh_c_dzc_harmonic_jit`.
+    Derivative of the harmonic oscillator classical Hamiltonian function with respect to
+    the conjugate `z` coordinate. This is an ingredient that calls the low-level
+    function `dh_c_dzc_harmonic_jit`.
 
     Required constants:
         - `harmonic_frequency`: Array of harmonic frequencies.
@@ -136,7 +140,8 @@ def dh_c_dzc_harmonic(model, parameters, **kwargs):
 
 def dh_c_dzc_free(model, parameters, **kwargs):
     """
-    Derivative of the free particle classical Hamiltonian function with respect to the conjugate `z` coordinate.
+    Derivative of the free particle classical Hamiltonian function with respect to the
+    conjugate `z` coordinate.
 
     Required constants:
         - `classical_coordinate_mass`: Mass of the classical coordinates.
@@ -226,7 +231,8 @@ def h_qc_diagonal_linear(model, parameters, **kwargs):
     :math:`H_{ii} = \sum_{j} \gamma_{ij} (z_{j} + z_{j}^*)`
 
     Required constants:
-        - `diagonal_linear_coupling`: Array of coupling constants (num_quantum_states, num_classical_coordinates).
+        - `diagonal_linear_coupling`: Array of coupling constants
+          (num_quantum_states, num_classical_coordinates).
     """
     del parameters
     z = kwargs["z"]
@@ -244,7 +250,8 @@ def dh_qc_dzc_diagonal_linear(model, parameters, **kwargs):
     Gradient of the diagonal linear quantum-classical coupling Hamiltonian.
 
     Required constants:
-        - `diagonal_linear_coupling`: Array of coupling constants (num_quantum_states, num_classical_coordinates).
+        - `diagonal_linear_coupling`: Array of coupling constants
+          (num_quantum_states, num_classical_coordinates).
     """
     batch_size = kwargs.get("batch_size", len(parameters.seed))
     num_states = model.constants.num_quantum_states
@@ -268,7 +275,9 @@ def dh_qc_dzc_diagonal_linear(model, parameters, **kwargs):
 
 def hop_harmonic(model, parameters, **kwargs):
     """
-    FSSH hop function for taking the classical coordinates to represent harmonic oscillators.
+    FSSH hop function for taking the classical coordinates to represent harmonic
+    oscillators.
+
     Determines the shift in the classical coordinates required to conserve energy
     following a hop between quantum states. The quantity ev_diff = e_final - e_initial
     is the energy difference between the final and initial quantum states and
@@ -330,6 +339,7 @@ def hop_harmonic(model, parameters, **kwargs):
 def hop_free(model, parameters, **kwargs):
     """
     FSSH hop function taking the classical coordinates to represent free particles.
+
     Determines the shift in the classical coordinates required to conserve energy
     following a hop between quantum states. The quantity ev_diff = e_final - e_initial
     is the energy difference between the final and initial quantum states and
@@ -379,8 +389,8 @@ def hop_free(model, parameters, **kwargs):
 
 def init_classical_boltzmann_harmonic(model, parameters, **kwargs):
     """
-    Initialize classical coordinates according to Boltzmann statistics taking the classical
-    coordinates to represent harmonic oscillators.
+    Initialize classical coordinates according to Boltzmann statistics taking the
+    classical coordinates to represent harmonic oscillators.
 
     Required constants:
         - `kBT`: Thermal quantum.
@@ -413,7 +423,8 @@ def init_classical_boltzmann_harmonic(model, parameters, **kwargs):
 
 def init_classical_wigner_harmonic(model, parameters, **kwargs):
     """
-    Initialize classical coordinates according to the Wigner distribution of the ground state of a harmonic oscillator.
+    Initialize classical coordinates according to the Wigner distribution of the ground
+    state of a harmonic oscillator.
 
     Required constants:
         - `kBT`: Thermal quantum.
@@ -452,9 +463,9 @@ def init_classical_wigner_harmonic(model, parameters, **kwargs):
 
 def init_classical_definite_position_momentum(model, parameters, **kwargs):
     """
-    Initialize classical coordinates with definite position and momentum.
-    The quantities init_position and init_momentum are the initial position and momentum,
-    and so should be numpy arrays of shape (num_classical_coordinates).
+    Initialize classical coordinates with definite position and momentum. The quantities
+    init_position and init_momentum are the initial position and momentum, and so should
+    be numpy arrays of shape (num_classical_coordinates).
 
     Required constants:
         - `classical_coordinate_mass`: Mass of the classical coordinates.
@@ -473,14 +484,16 @@ def init_classical_definite_position_momentum(model, parameters, **kwargs):
 
 def init_classical_wigner_coherent_state(model, parameters, **kwargs):
     """
-    Initialize classical coordinates according to the Wigner distribution of a coherent state of a harmonic oscillator.
+    Initialize classical coordinates according to the Wigner distribution of a coherent
+    state of a harmonic oscillator.
 
     :math:`exp(a\hat{b}^{\dagger} - a^{*}\hat{b})\vert 0\rangle`
 
     where `a` is the complex displacement parameter of the coherent state.
 
     Required constants:
-        - `coherent_state_displacement`: Array of complex displacement parameter for the coherent state.
+        - `coherent_state_displacement`: Array of complex displacement
+          parameter for the coherent state.
         - `harmonic_frequency`: Array of harmonic frequencies.
     """
     seed = kwargs["seed"]

--- a/qc_lab/model.py
+++ b/qc_lab/model.py
@@ -8,8 +8,8 @@ from qc_lab.constants import Constants
 
 class Model:
     """
-    The Model object provides the framework for defining the default constants of a model and
-    retrieving the ingredients of the model.
+    The Model object provides the framework for defining the default constants of a
+    model and retrieving the ingredients of the model.
     """
 
     def __init__(self, default_constants=None, constants=None):

--- a/qc_lab/models/fmo_complex.py
+++ b/qc_lab/models/fmo_complex.py
@@ -10,6 +10,7 @@ from qc_lab import ingredients
 class FMOComplex(Model):
     """
     A model representing a Fenna-Matthews-Olson (FMO) complex.
+
     All unitless quantities in this model are taken to be in units of kBT at 298.15 K.
     """
 
@@ -93,13 +94,15 @@ class FMOComplex(Model):
         )
 
         # To convert wavenumbers to units of kBT at T=298.15K we
-        # multiply by each value by 0.00509506 = (1/8065.544)[eV/cm^-1] / 0.0243342[eV]
+        # multiply each value by 0.00509506 =
+        # (1/8065.544)[eV/cm^-1] / 0.0243342[eV]
         # where 0.0243342[eV] is the value of kBT at 298.15K
-        # note that all other constants in this model must also be assumed to be
-        # in units of kBT at 298.15K.
+        # note that all other constants in this model must also be assumed to
+        # be in units of kBT at 298.15K.
         matrix_elements *= 0.00509506
 
-        # to reduce numerical errors we can offset the diagonal elements by their minimum value
+        # to reduce numerical errors we can offset the diagonal elements by
+        # their minimum value
         matrix_elements = matrix_elements - np.min(
             np.diag(matrix_elements)
         ) * np.identity(self.constants.num_quantum_states)

--- a/qc_lab/models/holstein_lattice.py
+++ b/qc_lab/models/holstein_lattice.py
@@ -9,9 +9,8 @@ from qc_lab import ingredients
 
 class HolsteinLattice(Model):
     """
-    A model representing a nearest-neighbor tight-binding model
-    with Holstein-type electron-phonon coupling with a
-    single optical mode.
+    A model representing a nearest-neighbor tight-binding model with Holstein-type
+    electron-phonon coupling with a single optical mode.
     """
 
     def __init__(self, constants=None):

--- a/qc_lab/simulation.py
+++ b/qc_lab/simulation.py
@@ -1,5 +1,6 @@
 """
-This module defines the Simulation class as well as the default settings for a simulation in QC Lab.
+This module defines the Simulation class as well as the default settings for a
+simulation in QC Lab.
 """
 
 import logging
@@ -37,9 +38,10 @@ class Simulation:
         """
         Initialize the timesteps for the simulation based on the parameters.
 
-        First ensures that dt_collect >= dt_update, if not it adjusts dt_collect to be equal to dt_update.
-        Then adjusts dt_collect to be the closest integer multiple of dt_update.
-        Then adjusts tmax to be the closest integer multiple of dt_collect.
+        First ensures that dt_collect >= dt_update, if not it adjusts dt_collect to be
+        equal to dt_update. Then adjusts dt_collect to be the closest integer multiple
+        of dt_update. Then adjusts tmax to be the closest integer multiple of
+        dt_collect.
         """
         tmax = self.settings.get("tmax")
         dt_update = self.settings.get("dt_update")
@@ -58,9 +60,11 @@ class Simulation:
                 "dt_update is greater than dt_collect, setting dt_collect to dt_update."
             )
 
-        # dt_collect_n is the number of update timesteps that defines a collect timestep.
+        # dt_collect_n is the number of update timesteps that defines a collect
+        # timestep.
         dt_collect_n = np.round(dt_collect / dt_update).astype(int)
-        # tmax_n is the number of update timesteps that defines the total simulation time.
+        # tmax_n is the number of update timesteps that defines the total
+        # simulation time.
         self.settings.tmax_n = np.round(tmax / dt_collect).astype(int) * dt_collect_n
         self.settings.tmax = self.settings.tmax_n * dt_update
         self.settings.dt_collect_n = dt_collect_n
@@ -69,7 +73,8 @@ class Simulation:
         self.settings.t_update = np.arange(0, self.settings.tmax_n + 1, 1) * dt_update
         # t_update_n is the update time array in terms of the number of update steps.
         self.settings.t_update_n = np.arange(0, self.settings.tmax_n + 1, 1)
-        # t_collect_n is the collect time array for the simulation in terms of the number of update steps.
+        # t_collect_n is the collect time array for the simulation in terms of
+        # the number of update steps.
         self.settings.t_collect_n = np.arange(
             0,
             self.settings.tmax_n + self.settings.dt_collect_n,

--- a/qc_lab/tasks/collect_tasks.py
+++ b/qc_lab/tasks/collect_tasks.py
@@ -1,6 +1,6 @@
 """
-This module contains the collect tasks which are used to collect data from the state
-or parameters objects into the output dictionary of the state object.
+This module contains the collect tasks which are used to collect data from the state or
+parameters objects into the output dictionary of the state object.
 """
 
 

--- a/qc_lab/tasks/initialization_tasks.py
+++ b/qc_lab/tasks/initialization_tasks.py
@@ -1,5 +1,7 @@
 """
-This module contains the tasks used to initialize quantities in the state or parameters objects.
+This module contains the tasks used to initialize quantities in the state or parameters
+objects.
+
 These are typically used in the initialization recipe of the algorithm object.
 """
 
@@ -20,14 +22,16 @@ def initialize_norm_factor(algorithm, sim, parameters, state, **kwargs):
 
 def initialize_branch_seeds(algorithm, sim, parameters, state, **kwargs):
     """
-    Convert seeds into branch seeds for deterministic surface hopping.
-    This is done by first assumign that the number of branches is equal to the number of quantum states.
-    Then, a branch index (state.branch_ind) is created which gives the branch index of each seed in the batch.
-    Then a new set of seeds is created by floor dividing the original seeds by the number of branches so that
-    the seeds corresponding to different branches within the same trajectory are the same.
+    Convert seeds into branch seeds for deterministic surface hopping. This is done by
+    first assumign that the number of branches is equal to the number of quantum states.
+    Then, a branch index (state.branch_ind) is created which gives the branch index of
+    each seed in the batch. Then a new set of seeds is created by floor dividing the
+    original seeds by the number of branches so that the seeds corresponding to
+    different branches within the same trajectory are the same.
 
-    Notably, this leads to the number of unique classical initial conditions being equal to the number of
-    trajectories divided by the number of branches in deterministic surface hopping.
+    Notably, this leads to the number of unique classical initial conditions
+    being equal to the number of trajectories divided by the number of
+    branches in deterministic surface hopping.
 
     Required constants:
         - num_quantum_states (int): Number of quantum states. Default: None.
@@ -38,9 +42,10 @@ def initialize_branch_seeds(algorithm, sim, parameters, state, **kwargs):
     else:
         num_branches = 1
     batch_size = sim.settings.batch_size
-    assert (
-        batch_size % num_branches == 0
-    ), "Batch size must be divisible by number of quantum states for deterministic surface hopping."
+    assert batch_size % num_branches == 0, (
+        "Batch size must be divisible by number of quantum states for"
+        " deterministic surface hopping."
+    )
     # Next, determine the number of trajectories that have been run by assuming that
     # the minimum seed in the current batch of seeds is the number of trajectories
     # that have been run modulo num_branches.
@@ -59,14 +64,16 @@ def initialize_branch_seeds(algorithm, sim, parameters, state, **kwargs):
 
 def initialize_z_mcmc(algorithm, sim, parameters, state, **kwargs):
     """
-    Initialize classical coordinates according to Boltzmann statistics using Markov-Chain
-    Monte Carlo with a Metropolis-Hastings algorithm.
+    Initialize classical coordinates according to Boltzmann statistics using Markov-
+    Chain Monte Carlo with a Metropolis-Hastings algorithm.
 
     Required constants:
-        - num_classical_coordinates (int): Number of classical coordinates. Default: None.
+        - num_classical_coordinates (int): Number of classical coordinates.
+          Default: None.
         - mcmc_burn_in_size (int): Number of burn-in steps. Default: 5000.
         - mcmc_std (float): Standard deviation for sampling. Default: 1.
-        - mcmc_h_c_separable (bool): If the classical Hamiltonian is separable. Default: True.
+        - mcmc_h_c_separable (bool): If the classical Hamiltonian is
+          separable. Default: True.
         - mcmc_init_z (np.ndarray): Initial sample. Default: None.
         - kBT (float): Thermal quantum. Default: None.
     """
@@ -159,7 +166,8 @@ def initialize_z_mcmc(algorithm, sim, parameters, state, **kwargs):
 
 def initialize_z(algorithm, sim, parameters, state, **kwargs):
     """
-    Initialize the classical coordinate by using the init_classical function from the model object.
+    Initialize the classical coordinate by using the init_classical function from the
+    model object.
 
     Required constants:
         - None.
@@ -178,7 +186,7 @@ def initialize_z(algorithm, sim, parameters, state, **kwargs):
 
 def state_to_parameters(algorithm, sim, parameters, state, **kwargs):
     """
-    Set parameters.parameters_name to state.state_name
+    Set parameters.parameters_name to state.state_name.
 
     Required constants:
         - None.
@@ -189,7 +197,7 @@ def state_to_parameters(algorithm, sim, parameters, state, **kwargs):
 
 def copy_in_state(algorithm, sim, parameters, state, **kwargs):
     """
-    Set state.dest_name to state.orig_name
+    Set state.dest_name to state.orig_name.
 
     Required constants:
         - None.
@@ -200,9 +208,8 @@ def copy_in_state(algorithm, sim, parameters, state, **kwargs):
 
 def initialize_active_surface(algorithm, sim, parameters, state, **kwargs):
     """
-    Initializes the active surface (act_surf), active surface index
-    (act_surf_ind) and initial active surface index (act_surf_ind_0)
-    for FSSH.
+    Initializes the active surface (act_surf), active surface index (act_surf_ind) and
+    initial active surface index (act_surf_ind_0) for FSSH.
 
     If fssh_deterministic is true it will set act_surf_ind_0 to be the same as
     the branch index and assert that the number of branches (num_branches)

--- a/qc_lab/tasks/task_functions.py
+++ b/qc_lab/tasks/task_functions.py
@@ -15,7 +15,8 @@ def gen_sample_gaussian(constants, z0=None, seed=None, separable=True):
     Generate a sample from a Gaussian distribution.
 
     Required constants:
-        - num_classical_coordinates (int): Number of classical coordinates. Default: None.
+        - num_classical_coordinates (int): Number of classical coordinates.
+          Default: None.
         - mcmc_std (float): Standard deviation for sampling. Default: 1.
     """
     if seed is not None:
@@ -43,8 +44,8 @@ def gen_sample_gaussian(constants, z0=None, seed=None, separable=True):
 @njit
 def calc_sparse_inner_product(inds, mels, shape, vec_l, vec_r):
     """
-    Given the indices, matrix elements and shape of a sparse matrix,
-    calculate the expectation value with a vector.
+    Given the indices, matrix elements and shape of a sparse matrix, calculate the
+    expectation value with a vector.
 
     Required constants:
         - None.
@@ -62,7 +63,8 @@ def calc_sparse_inner_product(inds, mels, shape, vec_l, vec_r):
 
 def analytic_der_couple_phase(algorithm, sim, parameters, state, eigvals, eigvecs):
     """
-    Calculates the phase change needed to fix the gauge using analytical derivative couplings.
+    Calculates the phase change needed to fix the gauge using analytical derivative
+    couplings.
 
     Required constants:
         - None.

--- a/qc_lab/tasks/update_tasks.py
+++ b/qc_lab/tasks/update_tasks.py
@@ -25,8 +25,8 @@ def update_t(algorithm, sim, parameters, state):
         - None.
     """
     batch_size = len(parameters.seed)
-    # the variable should store the time in each trajectory and should therefore be
-    # and array with length batch_size.
+    # the variable should store the time in each trajectory and should
+    # therefore be an array with length batch_size.
     state.t = np.ones(batch_size) * sim.t_ind * sim.settings.dt_update
     return parameters, state
 
@@ -36,7 +36,8 @@ def update_dh_c_dzc_finite_differences(algorithm, sim, parameters, state, **kwar
     Calculate the gradient of the classical Hamiltonian using finite differences.
 
     Required constants:
-        - num_classical_coordinates (int): Number of classical coordinates. Default: None.
+        - num_classical_coordinates (int): Number of classical
+          coordinates. Default: None.
     """
     z = kwargs["z"]
     name = kwargs.get("name", "dh_c_dzc")
@@ -84,8 +85,8 @@ def update_dh_c_dzc_finite_differences(algorithm, sim, parameters, state, **kwar
 
 def update_classical_forces(algorithm, sim, parameters, state, **kwargs):
     """
-    Update the gradient of the classical Hamiltonian
-    w.r.t. the conjugate classical coordinate.
+    Update the gradient of the classical Hamiltonian w.r.t. the conjugate classical
+    coordinate.
 
     Required constants:
         - None.
@@ -102,12 +103,15 @@ def update_classical_forces(algorithm, sim, parameters, state, **kwargs):
 
 def update_dh_qc_dzc_finite_differences(algorithm, sim, parameters, state, **kwargs):
     """
-    Calculate the gradient of the quantum-classical Hamiltonian using finite differences.
+    Calculate the gradient of the quantum-classical Hamiltonian using finite
+    differences.
 
     Required constants:
-        - num_classical_coordinates (int): Number of classical coordinates. Default: None.
+        - num_classical_coordinates (int): Number of classical
+          coordinates. Default: None.
         - num_quantum_states (int): Number of quantum states. Default: None.
-        - finite_difference_dz (float): Step size for finite differences. Default: 1e-6.
+        - finite_difference_dz (float): Step size for finite differences.
+          Default: 1e-6.
     """
     z = kwargs["z"]
     batch_size = kwargs.get("batch_size", len(z))
@@ -168,8 +172,8 @@ def update_dh_qc_dzc_finite_differences(algorithm, sim, parameters, state, **kwa
 
 def update_dh_qc_dzc(algorithm, sim, parameters, state, **kwargs):
     """
-    Update the gradient of the quantum-classical Hamiltonian
-    w.r.t. the conjugate classical coordinate.
+    Update the gradient of the quantum-classical Hamiltonian w.r.t. the conjugate
+    classical coordinate.
 
     Required constants:
         - None.
@@ -218,7 +222,8 @@ def update_quantum_classical_forces(algorithm, sim, parameters, state, **kwargs)
 
 def diagonalize_matrix(algorithm, sim, parameters, state, **kwargs):
     """
-    Diagonalizes a given matrix from the state object and stores the eigenvalues and eigenvectors in the state object.
+    Diagonalizes a given matrix from the state object and stores the eigenvalues and
+    eigenvectors in the state object.
 
     Required constants:
         - None.
@@ -243,8 +248,9 @@ def gauge_fix_eigs(algorithm, sim, parameters, state, **kwargs):
         with the previous eigenvector and used to maximize the overlap.
 
     if gauge_fixing == "phase_der_couple":
-        The phase of the eigenvector is determined by calculating the derivative couplings
-        and changed so that all the derivative couplings are real-valued.
+        The phase of the eigenvector is determined by calculating the
+        derivative couplings and changed so that all the derivative
+        couplings are real-valued.
 
     Required constants:
         - None.
@@ -316,9 +322,8 @@ def basis_transform_vec(algorithm, sim, parameters, state, **kwargs):
 
 def basis_transform_mat(algorithm, sim, parameters, state, **kwargs):
     """
-    Transforms a matrix "input_mat" to a new basis
-    defined by "basis" and stores it in the state object
-    with name "output_name".
+    Transforms a matrix "input_mat" to a new basis defined by "basis" and stores it in
+    the state object with name "output_name".
 
     Required constants:
         - None.
@@ -433,7 +438,8 @@ def update_hop_probs_fssh(algorithm, sim, parameters, state, **kwargs):
         state.wf_adb[np.arange(num_trajs * num_branches), act_surf_ind_flat] == 0
     ):
         logger.critical(
-            "Wavefunction in active surface is zero, cannot calculate hopping probabilities."
+            "Wavefunction in active surface is zero, cannot calculate "
+            "hopping probabilities."
         )
     hop_prob = -2.0 * np.real(
         prod
@@ -450,11 +456,12 @@ def update_hop_probs_fssh(algorithm, sim, parameters, state, **kwargs):
 
 def update_hop_inds_fssh(algorithm, sim, parameters, state, **kwargs):
     """
-    Determines which trajectories hop based on the hopping probabilities and which state they hop to.
-    Note that these will only hop if they are not frustrated by the hopping function.
+    Determines which trajectories hop based on the hopping probabilities and which state
+    they hop to. Note that these will only hop if they are not frustrated by the hopping
+    function.
 
-    Stores the indices of the hopping trajectories in state.hop_ind.
-    Stores the destination indices of the hops in state.hop_dest.
+    Stores the indices of the hopping trajectories in state.hop_ind. Stores the
+    destination indices of the hops in state.hop_dest.
     """
     if sim.algorithm.settings.fssh_deterministic:
         num_branches = sim.model.constants.num_quantum_states
@@ -510,8 +517,9 @@ def update_z_shift_fssh(algorithm, sim, parameters, state, **kwargs):
 def update_hop_vals_fssh(algorithm, sim, parameters, state, **kwargs):
     """
     Executes the hopping function for the hopping trajectories.
-    It stores the rescaled coordinates in state.z_rescaled
-    and the a Boolean registering if the hop was successful in state.hop_successful.
+
+    It stores the rescaled coordinates in state.z_rescaled and the a Boolean registering
+    if the hop was successful in state.hop_successful.
     """
 
     hop_ind = state.hop_ind
@@ -557,8 +565,8 @@ def update_hop_vals_fssh(algorithm, sim, parameters, state, **kwargs):
 
 def update_z_hop_fssh(algorithm, sim, parameters, state, **kwargs):
     """
-    Executes the post-hop updates for FSSH, rescaling the z coordinates and updating
-    the active surface indices, and wavefunctions.
+    Executes the post-hop updates for FSSH, rescaling the z coordinates and updating the
+    active surface indices, and wavefunctions.
     """
     state.z[state.hop_ind] += state.z_shift
     return parameters, state
@@ -568,7 +576,6 @@ def update_act_surf_hop_fssh(algorithm, sim, parameters, state, **kwargs):
     """
     Update the active surface, active surface index, and active surface wavefunction
     following a hop in FSSH.
-
     """
     if sim.algorithm.settings.fssh_deterministic:
         num_branches = sim.model.constants.num_quantum_states
@@ -681,11 +688,10 @@ def update_classical_energy(algorithm, sim, parameters, state, **kwargs):
 
 def update_classical_energy_fssh(algorithm, sim, parameters, state, **kwargs):
     """
-
-    Update the classical energy for FSSH simulations. If deterministic, the energy in each
-    branch is summed together with weights determined by the initial adiabatic populations.
-    If not deterministic (and so there is only one branch), the energy is computed for the
-    single branch.
+    Update the classical energy for FSSH simulations. If deterministic, the energy in
+    each branch is summed together with weights determined by the initial adiabatic
+    populations. If not deterministic (and so there is only one branch), the energy is
+    computed for the single branch.
 
     Required constants:
         - None.

--- a/qc_lab/variable.py
+++ b/qc_lab/variable.py
@@ -1,6 +1,9 @@
 """
-This module defines the Variable class, which is used to store time-dependent variables in QC Lab.
-It also defines a function to initialize parameter and state Variable objects for simulations.
+This module defines the Variable class, which is used to store time-dependent variables
+in QC Lab.
+
+It also defines a function to initialize parameter and state Variable objects for
+simulations.
 """
 
 import logging
@@ -42,7 +45,8 @@ class Variable:
         return state
 
     def __setstate__(self, state):
-        """Restore state during unpickling.
+        """
+        Restore state during unpickling.
 
         Args:
             state (dict): Object state.

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ if DISABLE_H5PY:
 
 install_requires = DEPENDENCIES
 
+
 class develop(_develop):
     def run(self):
         target = os.path.join(self.install_lib, "qc_lab", "_config.py")
@@ -35,6 +36,7 @@ class develop(_develop):
             f.write(f"DISABLE_H5PY = {DISABLE_H5PY}\n")
         super().run()
 
+
 class build_py(_build_py):
     def run(self):
         target = os.path.join(self.build_lib, "qc_lab", "_config.py")
@@ -43,7 +45,6 @@ class build_py(_build_py):
             f.write(f"DISABLE_NUMBA = {DISABLE_NUMBA}\n")
             f.write(f"DISABLE_H5PY = {DISABLE_H5PY}\n")
         super().run()
-
 
 
 setup(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,6 @@
-"""Tests for :class:`qc_lab.data.Data` save and load functionality."""
+"""
+Tests for :class:`qc_lab.data.Data` save and load functionality.
+"""
 
 import numpy as np
 
@@ -6,7 +8,9 @@ from qc_lab import Data
 
 
 def test_save_load_numpy_scalars_and_iterables(tmp_path):
-    """Ensure numpy scalar types and iterables persist through save/load."""
+    """
+    Ensure numpy scalar types and iterables persist through save/load.
+    """
 
     data = Data()
     data.data_dict = {
@@ -35,4 +39,3 @@ def test_save_load_numpy_scalars_and_iterables(tmp_path):
     assert isinstance(nested["inner_int32"], np.int32)
     assert nested["inner_int32"] == np.int32(7)
     assert np.array_equal(nested["inner_list"], np.asarray([8, 9]))
-

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,14 +1,19 @@
-""" 
+"""
 This module tests the serial and multiprocessing drivers for a few simple cases.
 """
+
 import pytest
+
 
 def test_drivers_spinboson():
     import numpy as np
-    from qc_lab import Simulation # import simulation class
-    from qc_lab.models import SpinBoson # import model class
-    from qc_lab.algorithms import MeanField # import algorithm class
-    from qc_lab.dynamics import serial_driver, parallel_driver_multiprocessing # import dynamics driver
+    from qc_lab import Simulation  # import simulation class
+    from qc_lab.models import SpinBoson  # import model class
+    from qc_lab.algorithms import MeanField  # import algorithm class
+    from qc_lab.dynamics import (
+        serial_driver,
+        parallel_driver_multiprocessing,
+    )  # import dynamics driver
 
     sim = Simulation()
     sim.settings.num_trajs = 200
@@ -16,48 +21,52 @@ def test_drivers_spinboson():
     sim.settings.tmax = 10
     sim.settings.dt_update = 0.01
 
-    sim.model = SpinBoson({
-        'V':0.5,
-        'E':0.5,
-        'A':100,
-        'W':0.1,
-        'l_reorg':0.005,
-        'boson_mass':1.0,
-        'kBT':1.0,
-
-    })
+    sim.model = SpinBoson(
+        {
+            "V": 0.5,
+            "E": 0.5,
+            "A": 100,
+            "W": 0.1,
+            "l_reorg": 0.005,
+            "boson_mass": 1.0,
+            "kBT": 1.0,
+        }
+    )
     sim.algorithm = MeanField()
     sim.model.initialize_constants()
-    sim.state.wf_db= np.zeros((sim.model.constants.num_quantum_states), dtype=complex)
+    sim.state.wf_db = np.zeros((sim.model.constants.num_quantum_states), dtype=complex)
     sim.state.wf_db[0] += 1.0
-    print('Running serial driver...')
+    print("Running serial driver...")
     data_serial = serial_driver(sim)
-    print('Running parallel multiprocessing driver...')
+    print("Running parallel multiprocessing driver...")
     data_parallel_multiprocessing = parallel_driver_multiprocessing(sim)
-    print('Comparing results...')
+    print("Comparing results...")
     for key, val in data_serial.data_dict.items():
         if isinstance(val, np.ndarray):
             assert np.allclose(val, data_parallel_multiprocessing.data_dict[key])
             # assert np.allclose(val, data_parallel_mpi.data_dict[key])
-    print('parallel and serial results match!')
+    print("parallel and serial results match!")
     return
+
 
 @pytest.mark.mpi
 def test_drivers_spinboson_mpi():
     """
-    This test runs the serial and parallel drivers for the SpinBoson model using MPI.
-    It compares the results to ensure they match.
+    This test runs the serial and parallel drivers for the SpinBoson model using MPI. It
+    compares the results to ensure they match.
 
     This test requires MPI to be set up and run with a command like:
     mpirun -n 4 pytest -m mpi -s tests/test_drivers.py
-
     """
     import numpy as np
-    from qc_lab import Simulation # import simulation class
-    from qc_lab.models import SpinBoson # import model class
-    from qc_lab.algorithms import MeanField # import algorithm class
-    from mpi4py import MPI # import MPI for parallel processing
-    from qc_lab.dynamics import serial_driver, parallel_driver_mpi # import dynamics driver
+    from qc_lab import Simulation  # import simulation class
+    from qc_lab.models import SpinBoson  # import model class
+    from qc_lab.algorithms import MeanField  # import algorithm class
+    from mpi4py import MPI  # import MPI for parallel processing
+    from qc_lab.dynamics import (
+        serial_driver,
+        parallel_driver_mpi,
+    )  # import dynamics driver
 
     sim = Simulation()
     sim.settings.num_trajs = 200
@@ -65,34 +74,36 @@ def test_drivers_spinboson_mpi():
     sim.settings.tmax = 10
     sim.settings.dt_update = 0.01
 
-    sim.model = SpinBoson({
-        'V':0.5,
-        'E':0.5,
-        'A':100,
-        'W':0.1,
-        'l_reorg':0.005,
-        'boson_mass':1.0,
-        'kBT':1.0,
-
-    })
+    sim.model = SpinBoson(
+        {
+            "V": 0.5,
+            "E": 0.5,
+            "A": 100,
+            "W": 0.1,
+            "l_reorg": 0.005,
+            "boson_mass": 1.0,
+            "kBT": 1.0,
+        }
+    )
     sim.algorithm = MeanField()
     sim.model.initialize_constants()
-    sim.state.wf_db= np.zeros((sim.model.constants.num_quantum_states), dtype=complex)
+    sim.state.wf_db = np.zeros((sim.model.constants.num_quantum_states), dtype=complex)
     sim.state.wf_db[0] += 1.0
 
     data_parallel_mpi = parallel_driver_mpi(sim)
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
-    print('finished running parallel driver on rank', rank)
+    print("finished running parallel driver on rank", rank)
     if rank == 0:
-        print('Running serial driver... on rank', rank)
+        print("Running serial driver... on rank", rank)
         data_serial = serial_driver(sim)
-        print('Comparing results...')
+        print("Comparing results...")
         for key, val in data_serial.data_dict.items():
             if isinstance(val, np.ndarray):
                 assert np.allclose(val, data_parallel_mpi.data_dict[key])
-        print('parallel and serial results match!')
+        print("parallel and serial results match!")
     return
+
 
 if __name__ == "__main__":
     test_drivers_spinboson()


### PR DESCRIPTION
## Summary
- Convert all docstrings to multi-line style with opening and closing quotes on separate lines
- Reformat comments and code to respect an 88-column limit using docformatter and Black

## Testing
- `pytest` *(fails: cannot load MPI library)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d86455708323af2c5f9bbc3c8563