### PR TITLE
Add optional progress bar setting to simulations

### DIFF
--- a/qc_lab/dynamics/dynamics.py
+++ b/qc_lab/dynamics/dynamics.py
@@ -10,8 +10,12 @@ def dynamics(sim, parameter, state, data):
     """
     Dynamics core for QC Lab.
     """
+    t_update_iterator = sim.settings.t_update_n
+    if getattr(sim.settings, "progress_bar", True):
+        t_update_iterator = tqdm(t_update_iterator)
+
     # Iterate over each time step.
-    for sim.t_ind in tqdm(sim.settings.t_update_n):
+    for sim.t_ind in t_update_iterator:
         if sim.t_ind == 0:
             # Execute initialization recipe.
             parameter, state = sim.algorithm.execute_recipe(

--- a/qc_lab/simulation.py
+++ b/qc_lab/simulation.py
@@ -24,6 +24,7 @@ class Simulation:
             "dt_collect": 0.1,
             "num_trajs": 100,
             "batch_size": 25,
+            "progress_bar": True,
         }
         settings = {**self.default_settings, **settings}
         self.settings = Constants()

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -16,6 +16,7 @@ def test_drivers_spinboson():
     )  # import dynamics driver
 
     sim = Simulation()
+    sim.settings.progress_bar = False
     sim.settings.num_trajs = 200
     sim.settings.batch_size = 50
     sim.settings.tmax = 10
@@ -69,6 +70,7 @@ def test_drivers_spinboson_mpi():
     )  # import dynamics driver
 
     sim = Simulation()
+    sim.settings.progress_bar = False
     sim.settings.num_trajs = 200
     sim.settings.batch_size = 50
     sim.settings.tmax = 10


### PR DESCRIPTION
## Summary
- add `progress_bar` boolean setting with default `True`
- conditionally enable tqdm progress bar based on simulation settings
- disable progress bar in driver tests

## Testing
- `pytest -m "not mpi" -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d4954db883238009a4dba85e34cf